### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/check_version.yml
+++ b/.github/workflows/check_version.yml
@@ -11,7 +11,7 @@ jobs:
 
     steps:
     - name: checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4.1.4
       with:
         token: ${{ secrets.VERSION_COMMIT_PAT }}
     - name: get version
@@ -22,6 +22,6 @@ jobs:
       id: set-version
       run: echo "version=$(cat RePoE/version.txt)" >> "$GITHUB_OUTPUT"
     - name: commit changes
-      uses: stefanzweifel/git-auto-commit-action@v4
+      uses: stefanzweifel/git-auto-commit-action@v5.0.1
       with:
         commit_message: "Version ${{ steps.set-version.outputs.version }}"

--- a/.github/workflows/export.yml
+++ b/.github/workflows/export.yml
@@ -14,30 +14,30 @@ jobs:
 
     steps:
     - name: checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4.1.4
       with:
         path: RePoE
     - name: checkout pypoe
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4.1.4
       with:
         repository: lvlvllvlvllvlvl/PyPoE
         path: PyPoE
     - name: checkout pob
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4.1.4
       with:
         repository: PathOfBuildingCommunity/PathOfBuilding
         path: PathOfBuilding
-    - uses: leafo/gh-actions-lua@v9
+    - uses: leafo/gh-actions-lua@v10.0.0
       with:
         luaVersion: luajit
-    - uses: leafo/gh-actions-luarocks@v4
+    - uses: leafo/gh-actions-luarocks@v4.3.0
     - name: install a lua dependencies
       run: |
         luarocks install dkjson
     - name: Install poetry
       run: pipx install poetry
     - name: setup python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5.1.0
       with:
         python-version: '3.11'
         cache: poetry
@@ -60,14 +60,14 @@ jobs:
       working-directory: RePoE/RePoE/data/
     - name: commit changes
       id: autocommit
-      uses: stefanzweifel/git-auto-commit-action@v4
+      uses: stefanzweifel/git-auto-commit-action@v5.0.1
       with:
         repository: RePoE
         commit_message: "[skip ci] Automated export"
     - id: date
       run: echo "ym=$(date +'%Y-%m')" >> "$GITHUB_OUTPUT"
     - name: lfs cache
-      uses: actions/cache@v3
+      uses: actions/cache@v4.0.2
       if: github.event_name == 'workflow_dispatch' || steps.autocommit.outputs.changes_detected == 'true'
       with:
         path: |
@@ -79,7 +79,7 @@ jobs:
       working-directory: RePoE
     - name: upload gh-pages artifact
       if: github.event_name == 'workflow_dispatch' || steps.autocommit.outputs.changes_detected == 'true'
-      uses: actions/upload-pages-artifact@v1
+      uses: actions/upload-pages-artifact@v3.0.1
       with:
         path: RePoE/RePoE/data/
 
@@ -100,9 +100,9 @@ jobs:
     steps:
       - name: deploy gh-pages
         id: deployment
-        uses: actions/deploy-pages@v1
+        uses: actions/deploy-pages@v4.0.5
       - name: trigger poetrage
-        uses: peter-evans/repository-dispatch@v2
+        uses: peter-evans/repository-dispatch@v3.0.0
         with:
           token: ${{ secrets.VERSION_COMMIT_PAT }}
           repository: lvlvllvlvllvlvl/poetrage

--- a/.github/workflows/update_workflows.yml
+++ b/.github/workflows/update_workflows.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4.1.4
         with:
           sparse-checkout: .github
           token: ${{ secrets.VERSION_COMMIT_PAT }}


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[stefanzweifel/git-auto-commit-action](https://github.com/stefanzweifel/git-auto-commit-action)** published a new release **[v5.0.1](https://github.com/stefanzweifel/git-auto-commit-action/releases/tag/v5.0.1)** on 2024-04-12T06:47:39Z
* **[peter-evans/repository-dispatch](https://github.com/peter-evans/repository-dispatch)** published a new release **[v3.0.0](https://github.com/peter-evans/repository-dispatch/releases/tag/v3.0.0)** on 2024-01-25T11:59:08Z
* **[actions/cache](https://github.com/actions/cache)** published a new release **[v4.0.2](https://github.com/actions/cache/releases/tag/v4.0.2)** on 2024-03-19T15:55:41Z
* **[actions/setup-python](https://github.com/actions/setup-python)** published a new release **[v5.1.0](https://github.com/actions/setup-python/releases/tag/v5.1.0)** on 2024-03-26T14:09:17Z
* **[actions/upload-pages-artifact](https://github.com/actions/upload-pages-artifact)** published a new release **[v3.0.1](https://github.com/actions/upload-pages-artifact/releases/tag/v3.0.1)** on 2024-02-07T06:59:16Z
* **[actions/checkout](https://github.com/actions/checkout)** published a new release **[v4.1.4](https://github.com/actions/checkout/releases/tag/v4.1.4)** on 2024-04-24T13:33:24Z
* **[actions/deploy-pages](https://github.com/actions/deploy-pages)** published a new release **[v4.0.5](https://github.com/actions/deploy-pages/releases/tag/v4.0.5)** on 2024-03-18T15:43:13Z
* **[leafo/gh-actions-luarocks](https://github.com/leafo/gh-actions-luarocks)** published a new release **[v4.3.0](https://github.com/leafo/gh-actions-luarocks/releases/tag/v4.3.0)** on 2022-03-25T22:01:46Z
* **[leafo/gh-actions-lua](https://github.com/leafo/gh-actions-lua)** published a new release **[v10.0.0](https://github.com/leafo/gh-actions-lua/releases/tag/v10.0.0)** on 2023-01-31T18:40:04Z
