### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/check_version.yml
+++ b/.github/workflows/check_version.yml
@@ -11,7 +11,7 @@ jobs:
 
     steps:
     - name: checkout
-      uses: actions/checkout@v4.1.7
+      uses: actions/checkout@v4.2.1
       with:
         token: ${{ secrets.VERSION_COMMIT_PAT }}
     - name: get version

--- a/.github/workflows/export.yml
+++ b/.github/workflows/export.yml
@@ -14,16 +14,16 @@ jobs:
 
     steps:
     - name: checkout
-      uses: actions/checkout@v4.1.7
+      uses: actions/checkout@v4.2.1
       with:
         path: RePoE
     - name: checkout pypoe
-      uses: actions/checkout@v4.1.7
+      uses: actions/checkout@v4.2.1
       with:
         repository: lvlvllvlvllvlvl/PyPoE
         path: PyPoE
     - name: checkout pob
-      uses: actions/checkout@v4.1.7
+      uses: actions/checkout@v4.2.1
       with:
         repository: PathOfBuildingCommunity/PathOfBuilding
         path: PathOfBuilding
@@ -80,7 +80,7 @@ jobs:
     - id: date
       run: echo "ym=$(date +'%Y-%m')" >> "$GITHUB_OUTPUT"
     - name: lfs cache
-      uses: actions/cache@v4.0.2
+      uses: actions/cache@v4.1.1
       if: github.event_name == 'workflow_dispatch' || steps.autocommit.outputs.changes_detected == 'true'
       with:
         path: RePoE/.git/lfs

--- a/.github/workflows/update_workflows.yml
+++ b/.github/workflows/update_workflows.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4.1.7
+      - uses: actions/checkout@v4.2.1
         with:
           sparse-checkout: .github
           token: ${{ secrets.VERSION_COMMIT_PAT }}


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[actions/cache](https://github.com/actions/cache)** published a new release **[v4.1.1](https://github.com/actions/cache/releases/tag/v4.1.1)** on 2024-10-08T17:09:10Z
* **[actions/checkout](https://github.com/actions/checkout)** published a new release **[v4.2.1](https://github.com/actions/checkout/releases/tag/v4.2.1)** on 2024-10-07T16:44:53Z
